### PR TITLE
９章

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -177,3 +177,17 @@ input {
     color: $state-danger-text;
   }
 }
+
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+  span {
+    margin-left: 20px;
+    font-weight: normal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,7 +19,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     redirect_to root_url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,6 +8,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       # ユーザーログイン後にユーザー情報のページにリダイレクトする
       log_in user
+      remember user
       redirect_to user
     else
       # エラーメッセージを作成する

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,13 +3,14 @@ class SessionsController < ApplicationController
   end
   
   def create
-    user = User.find_by(email: params[:session][:email].downcase)
+    @user = User.find_by(email: params[:session][:email].downcase)
     #if user && user.authenticate(params[:session][:password])
-    if user && user.authenticate(params[:session][:password])
+    if @user && @user.authenticate(params[:session][:password])
       # ユーザーログイン後にユーザー情報のページにリダイレクトする
-      log_in user
-      remember user
-      redirect_to user
+      log_in @user
+      #remember user
+      params[:session][:remember_me] == '1'? remember(@user) : forget(@user)
+      redirect_to @user
     else
       # エラーメッセージを作成する
       #flash[:danger] = 'Invalid email/password combination' # 本当は正しくない

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -17,6 +17,7 @@ module SessionsHelper
     if (user_id = session[:user_id])
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
+      #raise  # テストがパスすれば、この部分がテストされていないことがわかる
       user = User.find_by(id: user_id)
       if user && user.authenticated?(cookies[:remember_token])
         log_in user

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -4,16 +4,41 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
+  # ユーザーのセッションを永続的にする
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  # 記憶トークンcookieに対応するユーザーを表す
   def current_user
-    @current_user ||= User.find_by(id: session[:user_id])
+    #@current_user ||= User.find_by(id: session[:user_id])
+    if (user_id = session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.signed[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
+    end
   end
 
   def logged_in?
     !current_user.nil?
   end
 
+  # 永続セッションを破壊する
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
   # 現在のユーザーをログアウトする
   def log_out
+    forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
 
   # 渡されたトークンがダイジェストと一致したらtrueを返す
   def authenticated?(remember_token)
+    return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  attr_accessor :remember_token
   #before_save { self.email = email.downcase }
   before_save { email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
@@ -10,10 +11,33 @@ class User < ApplicationRecord
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
 
-  #  渡された文字列のハッシュ値を示す
-  def User.digest(string)
-    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
-                                                  BCrypt::Engine.cost
-    BCrypt::Password.create(string, cost: cost)
+  class << self
+    #  渡された文字列のハッシュ値を示す
+    def digest(string)
+      cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                    BCrypt::Engine.cost
+      BCrypt::Password.create(string, cost: cost)
+    end
+
+    # ランダムなトークンを返す
+    def new_token
+      SecureRandom.urlsafe_base64
+    end
+  end
+
+  # 永続セッションのためにユーザーをデータベースに記憶する
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
+  end
+
+  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  def authenticated?(remember_token)
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
+
+  # ユーザーのログイン情報を破壊する
+  def forget
+    update_attribute(:remember_digest, nil)
   end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,6 +11,11 @@
       <%= f.label :password %>
       <%= f.password_field :password, class: 'form-control' %>
 
+      <%= f.label :remember_me, class: "checkbox inline" do %>
+        <%= f.check_box :remember_me %>
+        <span>Remember me on this computer</span>
+      <% end %>
+
       <%= f.submit "Log in", class: "btn btn-primary" %>
     <% end %>
 

--- a/db/migrate/20180129125129_add_remember_digest_to_users.rb
+++ b/db/migrate/20180129125129_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180121153712) do
+ActiveRecord::Schema.define(version: 20180129125129) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20180121153712) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class SessionsHelperTest < ActionView::TestCase
+
+  def setup
+    @user = users(:michael)
+    remember(@user)
+  end
+
+  test "current_user returns right user when session is nil" do
+    assert_equal @user, current_user
+    assert is_logged_in?
+  end
+
+  test "current_user returns nil when remeber digest is wrong" do
+    @user.update_attribute(:remember_digest, User.digest(User.new_token))
+    assert_nil current_user
+  end
+end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -37,4 +37,19 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", logout_path,   count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
   end
+
+  test "login with remembering" do
+    log_in_as(@user, remember_me: '1')
+    assert_not_empty cookies['remember_token']
+    assert_equal @user.name, assigns(:user).name
+  end
+
+  test "login without remembering" do
+    # くっkーを保存してログイン
+    log_in_as(@user, remember_me: '1')
+    delete logout_path
+    # クッキー削除してログイン
+    log_in_as(@user, remember_me: '0')
+    assert_empty cookies['remember_token']
+  end
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -30,6 +30,8 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     delete logout_path
     assert_not is_logged_in?
     assert_redirected_to root_url
+    # ２番目のウィンドウでログアウトをクリックするユーザーをシュミレートする
+    delete logout_path
     follow_redirect!
     assert_select "a[href=?]", login_path
     assert_select "a[href=?]", logout_path,   count: 0

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -74,4 +74,8 @@ class UserTest < ActiveSupport::TestCase
     @user.password = @user.password_confirmation = "a" * 5
     assert_not @user.valid?
   end
+
+  test "autheticated? should return false for a user with nil disget" do
+    assert_not @user.authenticated?('')
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,5 +11,17 @@ class ActiveSupport::TestCase
     !session[:user_id].nil?
   end
 
+  # テストユーザーとしてログインする
+  def log_in_as(user)
+    session[:user_id] = user.id
+  end
+
+  class ActionDispatch::IntegrationTest
+    # テストユーザーとしてログインする
+    def log_in_as(user, password: 'password', remember_me: '1')
+      post login_path, params: { session: { email: user.email, password: password, remember_me: remember_me}}
+    end
+  end
+
   # Add more helper methods to be used by all tests here...
 end


### PR DESCRIPTION
- Railsでは、あるページから別のページに移動するときに状態を保持することができる。ページの状態を長期間保持したいときは、cookiesメソッドを使って永続的なセッションにする
- 記憶トークンと記憶ダイジェストをユーザーごとに関連付けて、永続的セッションが実現できる
- cookiesメソッドを使うと、ユーザーのブラウザにcookiesなどを保存できる
- ログイン状態は、セッションもしくはクッキーの状態に基づいて決定される
- セッションとクッキーをそれぞれ削除すると、ユーザーのログアウトが実現できる
- 三項演算子を使用すると、単純なif-then文をコンパクトに記述できる